### PR TITLE
use temporary files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,11 @@ matrix:
             - gcc-mingw-w64-i686
             - mingw-w64-i686-dev
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode10.1
       compiler: gcc
+      cache:
+        directories:
+          - $HOME/Library/Caches/Homebrew
       env:
         - CROSSCOMPILE=native
         - CXX_COMPILER=g++-9
@@ -45,8 +48,6 @@ branches:
   - master
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update               ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade cmake        ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc@9 | true ; fi
 
 script:

--- a/src/patchfile/PatchFile.h
+++ b/src/patchfile/PatchFile.h
@@ -54,7 +54,11 @@ class PatchFile {
 
     bool readFileInfo(FILE* fp, FileList* fileList);
     bool validateFiles(const FileList& fileList);
-    bool applyFiles(FILE* fp, const FileList& fileList);
+    bool applyFiles(
+        FILE* fp, const FileList& fileList, const std::string& suffix);
+    bool cleanupFiles(
+        const std::string& baseDir,
+        const std::string& suffix, bool isSucceeded);
     bool generateFile(const std::string& writePath, const File& file);
     bool updateFile(const std::string& writePath, const File& file);
 
@@ -62,6 +66,9 @@ class PatchFile {
         const std::string& readPath, uint8_t** buf, uint64_t* size);
     bool writeRawFile(
         const std::string& writePath, uint8_t* buf, uint64_t size);
+
+    const std::string generateSuffix();
+    bool stringEndsWith(const std::string& str, const std::string& suffix);
 };
 
 #endif  // SRC_PATCHFILE_PATCHFILE_H_

--- a/src/patchfile/PatchFile.h
+++ b/src/patchfile/PatchFile.h
@@ -3,6 +3,7 @@
 #define SRC_PATCHFILE_PATCHFILE_H_
 
 #include <string>
+#include <unordered_map>
 #include "FileList.h"
 
 extern "C" {
@@ -69,6 +70,11 @@ class PatchFile {
 
     const std::string generateSuffix();
     bool stringEndsWith(const std::string& str, const std::string& suffix);
+    const std::string trimSuffix(
+        const std::string& str, const std::string& suffix);
+    std::string applyNameMap(
+        const std::unordered_map<std::string, std::string>& map,
+        const std::string& before, const std::string& suffix);
 };
 
 #endif  // SRC_PATCHFILE_PATCHFILE_H_


### PR DESCRIPTION
パッチ適用中にこけた場合にロールバックができない状態だったのでロールバックできるようにする。
生成ファイルや削除対象のファイルにsuffixをつけて、最後にrenameして置き換えるようにする。

関連issue: #14 