### PR TITLE
use block size not to spend a lot of memory.

### DIFF
--- a/src/gui/patchgen_gui/mainwindow.ui
+++ b/src/gui/patchgen_gui/mainwindow.ui
@@ -52,7 +52,7 @@
       <rect>
        <x>20</x>
        <y>80</y>
-       <width>95</width>
+       <width>241</width>
        <height>16</height>
       </rect>
      </property>
@@ -81,8 +81,8 @@
       <rect>
        <x>20</x>
        <y>30</y>
-       <width>128</width>
-       <height>12</height>
+       <width>391</width>
+       <height>16</height>
       </rect>
      </property>
      <property name="autoFillBackground">
@@ -123,8 +123,8 @@
       <rect>
        <x>20</x>
        <y>30</y>
-       <width>119</width>
-       <height>12</height>
+       <width>381</width>
+       <height>16</height>
       </rect>
      </property>
      <property name="text">
@@ -169,8 +169,8 @@
       <rect>
        <x>20</x>
        <y>80</y>
-       <width>124</width>
-       <height>12</height>
+       <width>391</width>
+       <height>16</height>
       </rect>
      </property>
      <property name="text">
@@ -209,8 +209,8 @@
      <rect>
       <x>10</x>
       <y>330</y>
-      <width>20</width>
-      <height>12</height>
+      <width>241</width>
+      <height>16</height>
      </rect>
     </property>
     <property name="autoFillBackground">

--- a/src/gui/patchgen_gui/patchgen_gui_ja_JP.ts
+++ b/src/gui/patchgen_gui/patchgen_gui_ja_JP.ts
@@ -5,19 +5,16 @@
     <name>MainWindow</name>
     <message>
         <location filename="mainwindow.ui" line="35"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="126"/>
         <source>patchgen GUI ver. 0.2.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="48"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="127"/>
         <source>Patch file</source>
         <translation>パッチファイル</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="60"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="128"/>
         <source>executable</source>
         <translation>自己解凍形式</translation>
     </message>
@@ -25,51 +22,41 @@
         <location filename="mainwindow.ui" line="76"/>
         <location filename="mainwindow.ui" line="154"/>
         <location filename="mainwindow.ui" line="190"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="129"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="133"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="135"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="92"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="130"/>
         <source>Output patchfile location:</source>
         <translation>差分パッチ出力先:</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="119"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="131"/>
         <source>Sources</source>
         <translation>差分生成元データ</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="131"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="132"/>
         <source>Older version directory:</source>
         <translation>旧バージョンのディレクトリ:</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="177"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="134"/>
         <source>Newer version directory:</source>
         <translation>新バージョンのディレクトリ:</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="204"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="136"/>
         <source>Create</source>
         <translation>作成</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="220"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="137"/>
         <source>Log:</source>
         <translation>ログ:</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="245"/>
-        <location filename="../../../build/src/gui/patchgen_gui/patchgen_gui_autogen/include/ui_mainwindow.h" line="138"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }

--- a/src/patchfile/BZip2PatchFile.cc
+++ b/src/patchfile/BZip2PatchFile.cc
@@ -44,66 +44,8 @@ BZip2PatchFile::BZip2PatchFile() {
     readStream.read = bz2_read;
 
     // copy signature.
-    const char SIGNATURE[16] = "BZIP2 ver.1.00";
+    const char SIGNATURE[16] = "BZIP2 ver.1.01";
     memcpy(signature, SIGNATURE, sizeof(signature));
-}
-
-bool BZip2PatchFile::encode(
-    const std::string& oldDir,
-    const std::string& newDir,
-    const std::string& output,
-    bool isHiddenSearch,
-    const std::string& ignorePattern) {
-
-    // search directory diff.
-    FileList diffList = searchDiff(
-        oldDir, newDir, isHiddenSearch, ignorePattern);
-
-    // write file.
-    FILE* file = fopen(output.c_str(), "wb");
-    if (file == nullptr) {
-        std::cerr << "cannot create " << output << std::endl;
-        return false;
-    }
-
-    create(file, &diffList);
-
-    // flush.
-    fclose(file);
-
-    return true;
-}
-
-
-bool BZip2PatchFile::decode(
-    const std::string& targetDir,
-    const std::string& input) {
-
-    // read file.
-    FILE* file = fopen(input.c_str(), "rb");
-    if (file == nullptr) {
-        std::cerr << "cannot open " << input << std::endl;
-        return false;
-    }
-    bool ret = apply(targetDir, file);
-
-    // finish.
-    fclose(file);
-
-    return true;
-}
-
-bool BZip2PatchFile::decode(
-    const std::string& targetDir,
-    FILE *fp,
-    const uint64_t offset) {
-
-    // read file.
-    fileOffset = offset;
-    bool ret = apply(targetDir, fp);
-
-    // finish.
-    return ret;
 }
 
 bool BZip2PatchFile::openWriter(FILE* fp) {

--- a/src/patchfile/BZip2PatchFile.h
+++ b/src/patchfile/BZip2PatchFile.h
@@ -11,19 +11,7 @@ extern "C" {
 class BZip2PatchFile : public PatchFile {
  public:
     BZip2PatchFile();
-    bool encode(
-        const std::string& oldDir,
-        const std::string& newDir,
-        const std::string& output,
-        bool isHiddenSearch,
-        const std::string& ignorePattern);
-    bool decode(
-        const std::string& targetDir,
-        const std::string& input);
-    bool decode(
-            const std::string& targetDir,
-            FILE *fp,
-            const uint64_t offset);
+
  protected:
     bool openWriter(FILE* fp);
     bool closeWriter();

--- a/src/patchfile/FileList.cc
+++ b/src/patchfile/FileList.cc
@@ -154,6 +154,8 @@ FileList FileList::calcDiff(
                     // old directory is removed.
                     File fileOld = *oldItr;
                     fileOld.isRemove = true;
+                    fileOld.fileNewSize = 0;
+                    fileOld.oldFilename = fileOld.fullFilename;
                     // new file is added.
                     File fileNew = *newItr;
                     fileNew.isAdd = true;
@@ -173,9 +175,12 @@ FileList FileList::calcDiff(
                     // old file is removed.
                     File fileOld = *oldItr;
                     fileOld.isRemove = true;
+                    fileOld.fileNewSize = 0;
+                    fileOld.oldFilename = fileOld.fullFilename;
                     // new directory is added.
                     File fileNew = *newItr;
                     fileNew.isAdd = true;
+                    fileNew.fileNewSize = 0;
                     fileList.files.push_back(fileOld);
                     fileList.files.push_back(fileNew);
 
@@ -208,6 +213,8 @@ FileList FileList::calcDiff(
             // old file/directory is removed.
             File fileOld = *oldItr;
             fileOld.isRemove = true;
+            fileOld.fileNewSize = 0;
+            fileOld.oldFilename = fileOld.fullFilename;
             fileList.files.push_back(fileOld);
             oldItr++;
         } else {
@@ -218,6 +225,8 @@ FileList FileList::calcDiff(
             if (!newItr->isDirectory) {
                 fileNew.fileNewSize =
                     fs::file_size(TO_PATH(fileNew.fullFilename));
+            } else {
+                fileNew.fileNewSize = 0;
             }
             fileList.files.push_back(fileNew);
             newItr++;
@@ -238,6 +247,8 @@ FileList FileList::calcDiff(
         for (; oldItr != oldList.files.end(); oldItr++) {
             File fileOld = *oldItr;
             fileOld.isRemove = true;
+            fileOld.fileNewSize = 0;
+            fileOld.oldFilename = fileOld.fullFilename;
             fileList.files.push_back(fileOld);
         }
     }

--- a/src/patchfile/FileList.h
+++ b/src/patchfile/FileList.h
@@ -14,6 +14,7 @@ namespace fs = std::filesystem;
 #include <regex>
 #include <string>
 #include <list>
+#include <vector>
 
 #ifdef WINDOWS
 #define TO_PATH(x) File::charsToWchars((x))
@@ -37,10 +38,15 @@ struct File {
     uint64_t fileNewSize;
     uint32_t checkSum;
 
+    uint64_t numBlocks;
+    std::vector<uint32_t> oldBlockSizeList;
+    std::vector<uint32_t> newBlockSizeList;
+    std::vector<uint32_t> diffBlockSizeList;
+
  public:
     File() :
         isDirectory(false), isAdd(false), isRemove(false), isModify(false),
-        filePos(0), fileSize(0), checkSum(0) {}
+        filePos(0), fileSize(0), checkSum(0), numBlocks(0) {}
 
     static bool isEqual(const File& file1, const File& file2);
 #ifdef WINDOWS

--- a/src/patchfile/PatchFile.cc
+++ b/src/patchfile/PatchFile.cc
@@ -8,7 +8,7 @@ extern "C" {
 #include <cstring>
 #include <iostream>
 #include <random>
-#include <ctime>
+#include <ctime>    
 #include <iomanip>
 #include "PatchFile.h"
 
@@ -45,29 +45,107 @@ FileList PatchFile::searchDiff(
     return diffList;
 }
 
-void PatchFile::create(FILE* fp, FileList* fileList) {
+bool PatchFile::encode(
+    const std::string& oldDir,
+    const std::string& newDir,
+    const std::string& output,
+    bool isHiddenSearch,
+    const std::string& ignorePattern,
+    uint32_t blockSize) {
+
+    // search directory diff.
+    std::cout << "Check diff..." << std::endl;
+    FileList diffList = searchDiff(
+        oldDir, newDir, isHiddenSearch, ignorePattern);
+
+    // write file.
+    std::cout << std::endl << "Writing..." << std::endl;
+    FILE* file = fopen(output.c_str(), "wb");
+    if (file == nullptr) {
+        std::cerr << "cannot create " << output << std::endl;
+        return false;
+    }
+
+    create(file, &diffList, blockSize);
+
+    // flush.
+    fclose(file);
+
+    return true;
+}
+
+bool PatchFile::decode(
+    const std::string& targetDir,
+    const std::string& input) {
+
+    // read file.
+    FILE* file = fopen(input.c_str(), "rb");
+    if (file == nullptr) {
+        std::cerr << "cannot open " << input << std::endl;
+        return false;
+    }
+    bool ret = apply(targetDir, file);
+
+    // finish.
+    fclose(file);
+
+    return true;
+}
+
+bool PatchFile::decode(
+    const std::string& targetDir,
+    FILE *fp,
+    const uint64_t offset) {
+
+    // read file.
+    fileOffset = offset;
+    bool ret = apply(targetDir, fp);
+
+    // finish.
+    return ret;
+}
+
+void PatchFile::create(FILE* fp, FileList* fileList, uint32_t blockSize) {
     // 0) write signature.
+    if (isVerbose) {
+        std::cout << "Writing signature..." << std::endl;
+    }
     fwrite(signature, sizeof(char), sizeof(signature), fp);
 
     // 1) write headers. (filePos & fileSize must be zero.)
-    writeFileInfo(fp, *fileList);
+    if (isVerbose) {
+        std::cout << "Writing headers..." << std::endl;
+    }
+    writeFileInfo(fp, fileList, blockSize, true);
 
     // 2) write data.
-    std::cout << std::endl << "Writing..." << std::endl;
-    writeFileData(fp, fileList);
+    if (isVerbose) {
+        std::cout << "Writing data..." << std::endl;
+    }
+    writeFileData(fp, fileList, blockSize);
 
     // 3) re-write headers. (filePos & fileSize will be non-zero.)
-    writeFileInfo(fp, *fileList);
+    if (isVerbose) {
+        std::cout << "Rewriting headers..." << std::endl;
+    }
+    writeFileInfo(fp, fileList, blockSize, false);
 }
 
-void PatchFile::writeFileInfo(FILE* fp, const FileList& fileList) {
+void PatchFile::writeFileInfo(
+    FILE* fp, FileList* fileList, uint32_t blockSize, bool isFirstCall) {
     // move pointer to head.
     fseeko(fp, sizeof(signature), SEEK_SET);
 
-    uint32_t numEntries = fileList.files.size();
+    // version info.
+    uint32_t fill = 0xffffffff;
+    uint32_t version = 2;
+    fwrite(&fill, sizeof(uint32_t), 1, fp);
+    fwrite(&version, sizeof(uint32_t), 1, fp);
+
+    uint32_t numEntries = fileList->files.size();
     fwrite(&numEntries, sizeof(uint32_t), 1, fp);
 
-    for (auto entry : fileList.files) {
+    for (auto& entry : fileList->files) {
         // filename
         uint16_t length = entry.name.length();
         fwrite(&length, sizeof(uint16_t), 1, fp);
@@ -92,12 +170,47 @@ void PatchFile::writeFileInfo(FILE* fp, const FileList& fileList) {
         // checksum
         uint32_t checkSum = entry.checkSum;
         fwrite(&checkSum, sizeof(uint32_t), 1, fp);
+
+        // blockSize
+        if (isFirstCall) {
+            uint64_t numBlocks = entry.fileNewSize / (blockSize * 1024);
+            if (entry.fileNewSize % (blockSize * 1024) > 0) {
+                numBlocks++;
+            }
+            entry.numBlocks = numBlocks;
+            entry.oldBlockSizeList.resize(numBlocks);
+            entry.newBlockSizeList.resize(numBlocks);
+            entry.diffBlockSizeList.resize(numBlocks);
+        }
+
+        uint64_t numBlocks = entry.numBlocks;
+        fwrite(&numBlocks, sizeof(uint64_t), 1, fp);
+        for (auto value : entry.oldBlockSizeList) {
+            fwrite(&value, sizeof(uint32_t), 1, fp);
+        }
+        for (auto value : entry.newBlockSizeList) {
+            fwrite(&value, sizeof(uint32_t), 1, fp);
+        }
+        for (auto value : entry.diffBlockSizeList) {
+            fwrite(&value, sizeof(uint32_t), 1, fp);
+        }
+
+        if (isVerbose) {
+            std::cout << "Name: " << entry.name << std::endl;
+            std::cout << "Flags: " << entry.encodeFlags() << std::endl;
+            std::cout << "FilePos: " << filePos << std::endl;
+            std::cout << "FileSize: " << fileSize << std::endl;
+            std::cout << "FileNewSize: " << fileNewSize << std::endl;
+            std::cout << "Checksum: " << checkSum << std::endl;
+            std::cout << "NumBlocks: " << numBlocks << std::endl << std::endl;
+        }
     }
 }
 
-void PatchFile::writeFileData(FILE* fp, FileList* fileList) {
+void PatchFile::writeFileData(
+    FILE* fp, FileList* fileList, uint32_t blockSize) {
     for (auto& entry : fileList->files) {
-        if (entry.isDirectory || entry.isRemove) {
+        if (entry.isDirectory) {
             continue;
         }
 
@@ -105,17 +218,19 @@ void PatchFile::writeFileData(FILE* fp, FileList* fileList) {
 
         if (entry.isAdd) {
             entry.filePos = ftello(fp);
-            openWriter(fp);
-            writeAdditionalFile(entry);
-            closeWriter();
+            writeAdditionalFile(fp, &entry, blockSize);
             entry.fileSize = ftello(fp) - entry.filePos;
-
         } else if (entry.isModify) {
             entry.filePos = ftello(fp);
-            openWriter(fp);
-            writeUpdateFile(&entry);
-            closeWriter();
+            writeUpdateFile(fp, &entry, blockSize);
             entry.fileSize = ftello(fp) - entry.filePos;
+        } else if (entry.isRemove) {
+            entry.filePos = ftello(fp);
+            entry.fileSize = ftello(fp) - entry.filePos;
+        }
+
+        if (entry.isModify || entry.isRemove) {
+            entry.checkSum = calcCheckSum(entry.oldFilename);
         }
 
         if (entry.fileNewSize > 0) {
@@ -129,67 +244,141 @@ void PatchFile::writeFileData(FILE* fp, FileList* fileList) {
     }
 }
 
-void PatchFile::writeAdditionalFile(const File& file) {
-    // open new file.
-    uint64_t newFileSize;
-    uint8_t* bufNew;
-    if (!readRawFile(file.newFilename, &bufNew, &newFileSize)) {
-        return;
-    }
-
-    // old file (dummy)
-    uint64_t oldFileSize = 0;
-    uint8_t* bufOld = new uint8_t[oldFileSize+1];
-
-    // call bsdiff.
-    bsdiff(bufOld, oldFileSize, bufNew, newFileSize, &writeStream);
-
-    delete[] bufOld;
-    delete[] bufNew;
-}
-
-void PatchFile::writeUpdateFile(File* file) {
-    // open old file.
-    uint64_t oldFileSize;
-    uint8_t* bufOld;
-    if (!readRawFile(file->oldFilename, &bufOld, &oldFileSize)) {
-        return;
-    }
-
-    // open new file.
-    uint64_t newFileSize;
-    uint8_t* bufNew;
-    if (!readRawFile(file->newFilename, &bufNew, &newFileSize)) {
-        delete[] bufOld;
-        return;
+uint32_t PatchFile::calcCheckSum(const std::string& filePath) {
+    // check checksum.
+    uint64_t fileSize;
+    uint8_t* buf;
+    if (!readRawFile(filePath, &buf, &fileSize)) {
+        return 0;
     }
 
     // calc checksum.
     uint32_t checkSum = 0;
-    uint8_t* ptrOld = bufOld;
-    for (; ptrOld - bufOld < oldFileSize; ptrOld++) {
-        checkSum += *ptrOld;
+    uint8_t* ptr = buf;
+    for (; ptr - buf < fileSize; ptr++) {
+        checkSum += *ptr;
     }
-    file->checkSum = checkSum;
+    delete[] buf;
 
-    // call bsdiff.
-    bsdiff(bufOld, oldFileSize, bufNew, newFileSize, &writeStream);
+    return checkSum;
+}
+
+void PatchFile::writeAdditionalFile(
+    FILE* writeFp, File* file, uint32_t blockSize) {
+    uint64_t newFileSize;
+    uint64_t oldFileSize = 0;
+    uint32_t blockSizeBytes = blockSize * 1024;
+    uint8_t* bufNew = new uint8_t[blockSizeBytes+1];
+    uint8_t* bufOld = new uint8_t[oldFileSize+1];
+
+    FILE *fp = nullptr;
+    uint64_t prevPos = ftello(writeFp);
+    for (uint64_t i = 0; i < file->numBlocks; i++) {
+        // open new file.
+        if (!readRawFilePartial(
+            &fp, file->newFilename, bufNew, &newFileSize, blockSizeBytes)) {
+            break;
+        }
+
+        // open writer.
+        openWriter(writeFp);
+
+        // call bsdiff.
+        bsdiff(bufOld, oldFileSize, bufNew, newFileSize, &writeStream);
+
+        // close writer.
+        closeWriter();
+
+        // calc write size.
+        uint64_t nowPos = ftello(writeFp);
+        uint64_t delta = nowPos - prevPos;
+        prevPos = nowPos;
+
+        // set partial size.
+        file->oldBlockSizeList[i] = 0;
+        file->newBlockSizeList[i] = newFileSize;
+        file->diffBlockSizeList[i] = delta;
+    }
 
     delete[] bufOld;
     delete[] bufNew;
+
+    if (fp != nullptr) {
+        fclose(fp);
+    }
+}
+
+void PatchFile::writeUpdateFile(
+    FILE* writeFp, File* file, uint32_t blockSize) {
+    uint64_t oldFileSize;
+    uint64_t newFileSize;
+    uint32_t blockSizeBytes = blockSize * 1024;
+    uint8_t* bufOld = new uint8_t[blockSizeBytes+1];
+    uint8_t* bufNew = new uint8_t[blockSizeBytes+1];
+    FILE* inFp = nullptr;
+    FILE* outFp = nullptr;
+
+    uint64_t prevPos = ftello(writeFp);
+    for (uint64_t i = 0; i < file->numBlocks; i++) {
+        // open old file.
+        if (!readRawFilePartial(
+            &inFp, file->oldFilename, bufOld, &oldFileSize, blockSizeBytes)) {
+            break;
+        }
+
+        // open new file.
+        if (!readRawFilePartial(
+            &outFp, file->newFilename, bufNew, &newFileSize, blockSizeBytes)) {
+            break;
+        }
+
+        // open writer.
+        openWriter(writeFp);
+
+        // call bsdiff.
+        bsdiff(bufOld, oldFileSize, bufNew, newFileSize, &writeStream);
+
+        // close writer.
+        closeWriter();
+
+        uint64_t nowPos = ftello(writeFp);
+        uint64_t delta = nowPos - prevPos;
+        prevPos = nowPos;
+
+        // set partial size.
+        file->oldBlockSizeList[i] = oldFileSize;
+        file->newBlockSizeList[i] = newFileSize;
+        file->diffBlockSizeList[i] = delta;
+    }
+
+    delete[] bufOld;
+    delete[] bufNew;
+
+    if (inFp != nullptr) {
+        fclose(inFp);
+    }
+    if (outFp != nullptr) {
+        fclose(outFp);
+    }
 }
 
 bool PatchFile::apply(const std::string& targetDir, FILE* fp) {
     fseeko(fp, fileOffset, SEEK_SET);
 
-    // 0) skip signature.
-    char dummy[16] = { 0 };
-    if (fread(dummy, sizeof(char), 16, fp) < 16) {
+    // 0) check signature.
+    if (isVerbose) {
+        std::cout << "Check signature..." << std::endl;
+    }
+    char signature[16] = { 0 };
+    if (fread(signature, sizeof(char), 16, fp) < 16) {
         std::cerr << "invalid header." << std::endl;
         return false;
     }
 
     // 1) read headers.
+    if (isVerbose) {
+        std::cout << "Read headers..." << std::endl;
+    }
     FileList fileList;
     fileList.rootDir = targetDir;
     if (!readFileInfo(fp, &fileList)) {
@@ -198,6 +387,9 @@ bool PatchFile::apply(const std::string& targetDir, FILE* fp) {
     }
 
     // 2) validate file existence & checksum.
+    if (isVerbose) {
+        std::cout << "Validate files..." << std::endl;
+    }
     if (!validateFiles(fileList)) {
         return false;
     }
@@ -227,10 +419,22 @@ bool PatchFile::readFileInfo(FILE* fp, FileList* fileList) {
         return false;
     }
 
-    // get # of entries.
+    // get # of entries(ver. 1)
+    // 0xffffffff (ver. >= 2)
     uint32_t numEntries;
     if (fread(&numEntries, sizeof(uint32_t), 1, fp) < 1) {
         return false;
+    }
+
+    // get version and # of entries(ver. >= 2)
+    uint32_t version = 1;
+    if (numEntries == 0xffffffff) {
+        if (fread(&version, sizeof(uint32_t), 1, fp) < 1) {
+            return false;
+        }
+        if (fread(&numEntries, sizeof(uint32_t), 1, fp) < 1) {
+            return false;
+        }
     }
 
     for (uint32_t i=0; i < numEntries; i++) {
@@ -284,6 +488,53 @@ bool PatchFile::readFileInfo(FILE* fp, FileList* fileList) {
         }
         file.checkSum = checkSum;
 
+        if (version >= 2) {
+            uint64_t numBlocks;
+            if (fread(&numBlocks, sizeof(uint64_t), 1, fp) < 1) {
+                return false;
+            }
+            file.numBlocks = numBlocks;
+            file.oldBlockSizeList.resize(numBlocks);
+            file.newBlockSizeList.resize(numBlocks);
+            file.diffBlockSizeList.resize(numBlocks);
+
+            for (uint64_t j = 0; j < numBlocks; j++) {
+                uint32_t val;
+                if (fread(&val, sizeof(uint32_t), 1, fp) < 1) {
+                    return false;
+                }
+                file.oldBlockSizeList[j] = val;
+            }
+
+            for (uint64_t j = 0; j < numBlocks; j++) {
+                uint32_t val;
+                if (fread(&val, sizeof(uint32_t), 1, fp) < 1) {
+                    return false;
+                }
+                file.newBlockSizeList[j] = val;
+            }
+
+            for (uint64_t j = 0; j < numBlocks; j++) {
+                uint32_t val;
+                if (fread(&val, sizeof(uint32_t), 1, fp) < 1) {
+                    return false;
+                }
+                file.diffBlockSizeList[j] = val;
+            }
+        } else {
+            file.numBlocks = 0;
+        }
+
+        if (isVerbose) {
+            std::cout << "Name: " << file.name << std::endl;
+            std::cout << "Flags: " << file.encodeFlags() << std::endl;
+            std::cout << "FilePos: " << file.filePos << std::endl;
+            std::cout << "FileSize: " << file.fileSize << std::endl;
+            std::cout << "FileNewSize: " << file.fileNewSize << std::endl;
+            std::cout << "Checksum: " << file.checkSum << std::endl;
+            std::cout << "NumBlocks: " <<
+                file.numBlocks << std::endl << std::endl;
+        }
         fileList->files.push_back(file);
     }
 
@@ -301,27 +552,20 @@ bool PatchFile::validateFiles(const FileList& fileList) {
                     << " " << entry.name << " is not found." << std::endl;
                 return false;
             }
-        }
-        if (entry.isModify && !entry.isDirectory) {
-            // check checksum.
-            uint64_t fileSize;
-            uint8_t* buf;
-            if (!readRawFile(filePath, &buf, &fileSize)) {
-                return false;
-            }
-
-            // calc checksum.
-            uint32_t checkSum = 0;
-            uint8_t* ptr = buf;
-            for (; ptr - buf < fileSize; ptr++) {
-                checkSum += *ptr;
-            }
-            delete[] buf;
-
-            if (checkSum != entry.checkSum) {
-                std::cerr << "checksum " << entry.name
-                    << " is not match." << std::endl;
-                return false;
+            if (!entry.isDirectory) {
+                // calc checksum
+                uint32_t checkSum = calcCheckSum(filePath);
+                if (isVerbose) {
+                    std::cout << "Name: " << entry.name << std::endl;
+                    std::cout << "FileCheckSum: " << checkSum << std::endl;
+                    std::cout << "CompareCheckSum: "
+                        << entry.checkSum << std::endl;
+                }
+                if (checkSum != entry.checkSum) {
+                    std::cerr << "checksum " << entry.name
+                        << " is not match." << std::endl;
+                    return false;
+                }
             }
         }
     }
@@ -376,9 +620,7 @@ bool PatchFile::applyFiles(
                 std::string filePath =
                     fileList.rootDir + "/" + renamedName;
                 fseeko(fp, fileOffset + entry.filePos, SEEK_SET);
-                openReader(fp);
-                generateFile(filePath, entry);
-                closeReader();
+                generateFile(fp, filePath, entry);
             } else if (entry.isRemove) {
                 std::string beforeName = applyNameMap(
                     nameMap, entry.name, "");
@@ -411,9 +653,7 @@ bool PatchFile::applyFiles(
                 }
 
                 fseeko(fp, fileOffset + entry.filePos, SEEK_SET);
-                openReader(fp);
-                updateFile(workingFilePath, entry);
-                closeReader();
+                updateFile(fp, workingFilePath, entry);
             }
         }
     }
@@ -543,47 +783,188 @@ bool PatchFile::cleanupFiles(
 }
 
 bool PatchFile::generateFile(
-    const std::string& writePath, const File& file) {
-    // allocate new file buffer.
-    off_t newFileSize = file.fileNewSize;
-    uint8_t* bufNew = new uint8_t[newFileSize+1];
-    memset(bufNew, 0, newFileSize + 1);
+    FILE* readFp, const std::string& writePath, const File& file) {
 
-    // old file (dummy)
-    off_t oldFileSize = 0;
-    uint8_t* bufOld = new uint8_t[oldFileSize+1];
+    if (file.numBlocks == 0) {
+        // allocate new file buffer.
+        uint64_t newFileSize = file.fileNewSize;
+        uint8_t* bufNew = new uint8_t[newFileSize+1];
+        memset(bufNew, 0, newFileSize + 1);
 
-    // call bspatch.
-    bspatch(bufOld, oldFileSize, bufNew, newFileSize, &readStream);
+        // old file (dummy)
+        uint64_t oldFileSize = 0;
+        uint8_t* bufOld = new uint8_t[oldFileSize+1];
 
-    // write file.
-    bool ret = writeRawFile(writePath, bufNew, newFileSize);
+        // open reader
+        openReader(readFp);
+
+        // call bspatch.
+        bspatch(bufOld, oldFileSize, bufNew, newFileSize, &readStream);
+
+        // close reader.
+        closeReader();
+
+        // write file.
+        bool ret = writeRawFile(writePath, bufNew, newFileSize);
+        delete[] bufOld;
+        delete[] bufNew;
+
+        return ret;
+    }
+
+    // allocate file buffer.
+    uint8_t* bufNew = new uint8_t[file.newBlockSizeList[0] + 1];
+    uint8_t* bufOld = new uint8_t[1];
+    memset(bufNew, 0, file.newBlockSizeList[0] + 1);
+
+    FILE *fp = nullptr;
+    bool ret = true;
+    for (size_t i = 0; i < file.numBlocks; i++) {
+        uint64_t newFileSize = file.newBlockSizeList[i];
+        uint64_t oldFileSize = 0;
+
+        std::string tmpFileName = file.fullFilename + ".tmp";
+        FILE* tmpFp = createTempFile(
+            readFp, file.diffBlockSizeList[i], tmpFileName);
+        if (tmpFp == nullptr) {
+            ret = false;
+            break;
+        }
+
+        // open reader
+        openReader(tmpFp);
+
+        // call bspatch.
+        bspatch(bufOld, oldFileSize, bufNew, newFileSize, &readStream);
+
+        // close reader.
+        closeReader();
+        fclose(tmpFp);
+
+        try {
+            fs::remove(TO_PATH(tmpFileName));
+        } catch (fs::filesystem_error& ex) {
+            std::cerr << "cannot remove " << tmpFileName << std::endl;
+        }
+
+        // write file.
+        ret = writeRawFilePartial(&fp, writePath, bufNew, newFileSize);
+        if (!ret) {
+            break;
+        }
+    }
+
     delete[] bufOld;
     delete[] bufNew;
+    if (fp != nullptr) {
+        fclose(fp);
+    }
 
     return ret;
 }
 
 bool PatchFile::updateFile(
-    const std::string& writePath, const File& file) {
-    // open old file.
-    uint64_t oldFileSize;
-    uint8_t* bufOld;
-    if (!readRawFile(writePath, &bufOld, &oldFileSize)) {
-        return false;
+    FILE* readFp, const std::string& writePath, const File& file) {
+
+    if (file.numBlocks == 0) {
+        // open old file.
+        uint64_t oldFileSize;
+        uint8_t* bufOld;
+        if (!readRawFile(writePath, &bufOld, &oldFileSize)) {
+            return false;
+        }
+
+        // allocate new file buffer.
+        uint64_t newFileSize = file.fileNewSize;
+        uint8_t* bufNew = new uint8_t[newFileSize+1];
+
+        // open reader
+        openReader(readFp);
+
+        // call bspatch.
+        bspatch(bufOld, oldFileSize, bufNew, newFileSize, &readStream);
+
+        // close reader.
+        closeReader();
+
+        // write file.
+        bool ret = writeRawFile(writePath, bufNew, newFileSize);
+        delete[] bufOld;
+        delete[] bufNew;
+
+        return ret;
     }
 
-    // allocate new file buffer.
-    uint64_t newFileSize = file.fileNewSize;
-    uint8_t* bufNew = new uint8_t[newFileSize+1];
+    // allocate file buffer.
+    uint8_t* bufNew = new uint8_t[file.newBlockSizeList[0] + 1];
+    uint8_t* bufOld = new uint8_t[file.oldBlockSizeList[0] + 1];
+    memset(bufNew, 0, file.newBlockSizeList[0] + 1);
 
-    // call bspatch.
-    bspatch(bufOld, oldFileSize, bufNew, newFileSize, &readStream);
+    FILE *inFp = nullptr;
+    FILE *outFp = nullptr;
+    bool ret = true;
+    for (size_t i = 0; i < file.numBlocks; i++) {
+        uint64_t newFileSize = file.newBlockSizeList[i];
+        uint64_t oldFileSize;
 
-    // write file.
-    bool ret = writeRawFile(writePath, bufNew, newFileSize);
+        ret = readRawFilePartial(
+            &inFp, writePath, bufOld, &oldFileSize, file.oldBlockSizeList[i]);
+        if (!ret) {
+            break;
+        }
+
+        std::string tmpFileName = writePath + ".tmp";
+        FILE* tmpFp = createTempFile(
+            readFp, file.diffBlockSizeList[i], tmpFileName);
+        if (tmpFp == nullptr) {
+            ret = false;
+            break;
+        }
+
+        // open reader
+        openReader(tmpFp);
+
+        // call bspatch.
+        bspatch(bufOld, oldFileSize, bufNew, newFileSize, &readStream);
+
+        // close reader.
+        closeReader();
+        fclose(tmpFp);
+
+        try {
+            fs::remove(TO_PATH(tmpFileName));
+        } catch (fs::filesystem_error& ex) {
+            std::cerr << "cannot remove " << tmpFileName << std::endl;
+        }
+
+        // write file.
+        ret = writeRawFilePartial(
+            &outFp, writePath + ".mod", bufNew, newFileSize);
+        if (!ret) {
+            break;
+        }
+    }
+
     delete[] bufOld;
     delete[] bufNew;
+    if (inFp != nullptr) {
+        fclose(inFp);
+    }
+    if (outFp != nullptr) {
+        fclose(outFp);
+    }
+
+    try {
+        fs::remove(TO_PATH(writePath));
+    } catch (fs::filesystem_error& ex) {
+        std::cerr << "cannot remove " << writePath << std::endl;
+    }
+    try {
+        fs::rename(TO_PATH(writePath + ".mod"), TO_PATH(writePath));
+    } catch (fs::filesystem_error& ex) {
+        std::cerr << "cannot rename " << writePath << ".mod"
+            << " to "  << writePath << std::endl;
+    }
 
     return ret;
 }
@@ -673,6 +1054,125 @@ bool PatchFile::writeRawFile(
 
     fclose(fp);
     return ret;
+}
+
+bool PatchFile::readRawFilePartial(
+    FILE** fp, const std::string& readPath,
+    uint8_t* buf, uint64_t* size, uint32_t blockSize) {
+
+    if (*fp == nullptr) {
+        *fp = fopen(readPath.c_str(), "rb");
+        if (*fp == nullptr) {
+            std::cerr << "cannot read " << readPath << std::endl;
+            return false;
+        }
+    }
+
+    bool ret = true;
+    const int BUFFER_SIZE = 1024;
+    uint8_t* ptr = buf;
+    int readSize = 0;
+    uint64_t totalRead = 0;
+    do {
+        if (totalRead + BUFFER_SIZE > blockSize) {
+            readSize = blockSize - totalRead;
+        } else {
+            readSize = BUFFER_SIZE;
+        }
+
+        if (readSize > 0) {
+            readSize = fread(ptr, sizeof(char), readSize, *fp);
+            if (readSize < 0) {
+                std::cerr << "error occurred in reading. val="
+                    << readSize << std::endl;
+                ret = false;
+                *size = 0;
+                break;
+            }
+            totalRead += readSize;
+            ptr += readSize;
+        }
+    } while (readSize > 0);
+
+    if (ret) {
+        *size = totalRead;
+    }
+    return ret;
+}
+
+bool PatchFile::writeRawFilePartial(
+    FILE** fp, const std::string& writePath,
+    uint8_t* buf, uint64_t size) {
+
+    if (*fp == nullptr) {
+        *fp = fopen(writePath.c_str(), "wb");
+        if (fp == nullptr) {
+            std::cerr << "cannot write " << writePath << std::endl;
+            return false;
+        }
+    }
+
+    bool ret = true;
+    const int BUFFER_SIZE = 1024;
+    uint8_t* ptr = buf;
+    int writeSize = 0;
+    uint64_t totalWrite = 0;
+    do {
+        if (totalWrite + BUFFER_SIZE > size) {
+            writeSize = size - totalWrite;
+        } else {
+            writeSize = BUFFER_SIZE;
+        }
+
+        if (writeSize > 0) {
+            writeSize = fwrite(ptr, sizeof(char), writeSize, *fp);
+            if (writeSize < 0) {
+                std::cerr << "error occurred in writing. val="
+                    << writeSize << std::endl;
+                ret = false;
+                break;
+            }
+            totalWrite += writeSize;
+            ptr += writeSize;
+        }
+    } while (writeSize > 0);
+
+    return ret;
+}
+
+FILE* PatchFile::createTempFile(
+    FILE* fp, uint64_t size, const std::string& filePath) {
+
+    FILE *writeFp = fopen(filePath.c_str(), "wb");
+    if (writeFp == nullptr) {
+        return nullptr;
+    }
+
+    const int BUFFER_SIZE = 1024;
+    uint8_t* buf = new uint8_t[BUFFER_SIZE + 1];
+    int readSize = 0;
+    uint64_t totalRead = 0;
+    do {
+        if (totalRead + BUFFER_SIZE > size) {
+            readSize = size - totalRead;
+        } else {
+            readSize = BUFFER_SIZE;
+        }
+
+        if (readSize > 0) {
+            readSize = fread(buf, sizeof(char), readSize, fp);
+            if (readSize < 0) {
+                std::cerr << "error occurred in reading. val="
+                    << readSize << std::endl;
+                break;
+            }
+            totalRead += readSize;
+            fwrite(buf, sizeof(char), readSize, writeFp);
+        }
+    } while (readSize > 0);
+
+    fclose(writeFp);
+    return fopen(filePath.c_str(), "rb");
 }
 
 const std::string PatchFile::generateSuffix() {

--- a/src/patchfile/PatchFile.h
+++ b/src/patchfile/PatchFile.h
@@ -14,25 +14,30 @@ extern "C" {
 class PatchFile {
  public:
     PatchFile() {}
-    virtual bool encode(
+    bool encode(
         const std::string& oldDir,
         const std::string& newDir,
         const std::string& output,
         bool isHiddenSearch,
-        const std::string& ignorePattern) = 0;
-    virtual bool decode(
+        const std::string& ignorePattern,
+        uint32_t blockSize);
+    bool decode(
         const std::string& targetDir,
-        const std::string& input) = 0;
-    virtual bool decode(
+        const std::string& input);
+    bool decode(
         const std::string& targetDir,
         FILE *fp,
-        const uint64_t offset) = 0;
+        const uint64_t offset);
+    void setVerbose(bool value) {
+        isVerbose = value;
+    }
 
  protected:
     bsdiff_stream writeStream;
     bspatch_stream readStream;
     char signature[16] = { 0 };
     uint64_t fileOffset = 0;
+    bool isVerbose = false;
 
     virtual bool openWriter(FILE* fp) = 0;
     virtual bool closeWriter() = 0;
@@ -44,15 +49,19 @@ class PatchFile {
         const std::string& newDir,
         bool isHiddenSearch,
         const std::string& ignorePattern);
-    void create(FILE* fp, FileList* fileList);
+    void create(FILE* fp, FileList* fileList, uint32_t blockSize);
     bool apply(const std::string& targetDir, FILE* fp);
 
  private:
-    void writeFileInfo(FILE* fp, const FileList& fileList);
-    void writeFileData(FILE* fp, FileList* fileList);
-    void writeAdditionalFile(const File& file);
-    void writeUpdateFile(File* file);
+    void writeFileInfo(
+        FILE* fp, FileList* fileList, uint32_t blockSize, bool isFirstCall);
+    void writeFileData(FILE* fp, FileList* fileList, uint32_t blockSize);
+    void writeAdditionalFile(
+        FILE* writeFp, File* file, uint32_t blockSize);
+    void writeUpdateFile(
+        FILE* writeFp, File* file, uint32_t blockSize);
 
+    uint32_t calcCheckSum(const std::string& filePath);
     bool readFileInfo(FILE* fp, FileList* fileList);
     bool validateFiles(const FileList& fileList);
     bool applyFiles(
@@ -60,13 +69,23 @@ class PatchFile {
     bool cleanupFiles(
         const std::string& baseDir,
         const std::string& suffix, bool isSucceeded);
-    bool generateFile(const std::string& writePath, const File& file);
-    bool updateFile(const std::string& writePath, const File& file);
+    bool generateFile(
+        FILE* readFp, const std::string& writePath, const File& file);
+    bool updateFile(
+        FILE* readFp, const std::string& writePath, const File& file);
 
     bool readRawFile(
         const std::string& readPath, uint8_t** buf, uint64_t* size);
     bool writeRawFile(
         const std::string& writePath, uint8_t* buf, uint64_t size);
+    bool readRawFilePartial(
+        FILE** fp, const std::string& readPath,
+        uint8_t* buf, uint64_t* size, uint32_t blockSize);
+    bool writeRawFilePartial(
+        FILE** fp, const std::string& writePath,
+        uint8_t* buf, uint64_t size);
+    FILE* createTempFile(
+        FILE* baseFp, uint64_t size, const std::string& filePath);
 
     const std::string generateSuffix();
     bool stringEndsWith(const std::string& str, const std::string& suffix);

--- a/src/patchfile/PlainPatchFile.cc
+++ b/src/patchfile/PlainPatchFile.cc
@@ -44,64 +44,8 @@ PlainPatchFile::PlainPatchFile() {
     readStream.read = plain_read;
 
     // copy signature.
-    const char SIGNATURE[16] = "PLAIN ver.1.00";
+    const char SIGNATURE[16] = "PLAIN ver.1.01";
     memcpy(signature, SIGNATURE, sizeof(signature));
-}
-
-bool PlainPatchFile::encode(
-    const std::string& oldDir,
-    const std::string& newDir,
-    const std::string& output,
-    bool isHiddenSearch,
-    const std::string& ignorePattern) {
-
-    // search directory diff.
-    FileList diffList = searchDiff(
-        oldDir, newDir, isHiddenSearch, ignorePattern);
-
-    // write file.
-    FILE* file = fopen(output.c_str(), "wb");
-    if (file == nullptr) {
-        std::cerr << "cannot create " << output << std::endl;
-        return false;
-    }
-    create(file, &diffList);
-
-    // flush.
-    fclose(file);
-
-    return true;
-}
-
-bool PlainPatchFile::decode(
-    const std::string& targetDir,
-    const std::string& input) {
-
-    // read file.
-    FILE* file = fopen(input.c_str(), "rb");
-    if (file == nullptr) {
-        std::cerr << "cannot open " << input << std::endl;
-        return false;
-    }
-    bool ret = apply(targetDir, file);
-
-    // finish.
-    fclose(file);
-
-    return ret;
-}
-
-bool PlainPatchFile::decode(
-    const std::string& targetDir,
-    FILE *fp,
-    const uint64_t offset) {
-
-    // read file.
-    fileOffset = offset;
-    bool ret = apply(targetDir, fp);
-
-    // finish.
-    return ret;
 }
 
 bool PlainPatchFile::openWriter(FILE* fp) {

--- a/src/patchfile/PlainPatchFile.h
+++ b/src/patchfile/PlainPatchFile.h
@@ -8,19 +8,6 @@
 class PlainPatchFile : public PatchFile {
  public:
     PlainPatchFile();
-    bool encode(
-        const std::string& oldDir,
-        const std::string& newDir,
-        const std::string& output,
-        bool isHiddenSearch,
-        const std::string& ignorePattern);
-    bool decode(
-        const std::string& targetDir,
-        const std::string& input);
-    bool decode(
-        const std::string& targetDir,
-        FILE *fp,
-        const uint64_t offset);
 
  protected:
     bool openWriter(FILE* fp);


### PR DESCRIPTION
bsdiffは17倍のメモリを消費するので、大きなファイルに対して実施するとメモリ消費量がとんでもないことになる。
そのため、ブロックサイズ(デフォルト=64MB)でファイルを分割し、ブロック単位で比較してパッチを生成することにする。

関連issue: #17 