### PR TITLE
modify FileAccess::fileCopy()

### DIFF
--- a/src/lib/FileAccess.cc
+++ b/src/lib/FileAccess.cc
@@ -166,13 +166,13 @@ bool FileAccess::writeBlock(
     return ret;
 }
 
-bool FileAccess::createTempFile(
+FILE* FileAccess::createTempFile(
     const std::string& filePath, FILE* fp, uint64_t size) {
 
-    FILE *writeFp = openWriteFile(filePath.c_str());
+    FILE *writeFp = fopen(filePath.c_str(), "wb+");
     if (writeFp == nullptr) {
         std::cerr << "cannot create " << filePath << std::endl;
-        return false;
+        return nullptr;
     }
 
     bool ret = true;
@@ -200,14 +200,16 @@ bool FileAccess::createTempFile(
         }
     } while (readSize > 0);
 
-    closeFile(writeFp);
     delete[] buf;
 
     if (!ret) {
+        fclose(writeFp);
         removeFile(filePath);
+        return nullptr;
     }
 
-    return ret;
+    fseeko(writeFp, 0, SEEK_SET);
+    return writeFp;
 }
 
 uint32_t FileAccess::calcCheckSum(const std::string& filePath) {

--- a/src/lib/FileAccess.h
+++ b/src/lib/FileAccess.h
@@ -51,11 +51,11 @@ class FileAccess {
     uint64_t getFileSize(const std::string& filePath);
     bool createDirectory(const std::string& filePath);
     bool copyFile(
-        const std::string& destPath,
-        const std::string& srcPath);
+        const std::string& srcPath,
+        const std::string& destPath);
     bool renameFile(
-        const std::string& destPath,
-        const std::string& srcPath);
+        const std::string& srcPath,
+        const std::string& destPath);
     bool removeFile(const std::string& filePath);
     bool isFileEqual(
         const std::string& file1, const std::string& file2);

--- a/src/lib/FileAccess.h
+++ b/src/lib/FileAccess.h
@@ -38,7 +38,7 @@ class FileAccess {
         FILE* fp, void* buffer, uint64_t* size, uint64_t blockSize);
     bool writeBlock(
         FILE* fp, const void* buffer, uint64_t size);
-    bool createTempFile(
+    FILE* createTempFile(
         const std::string& filePath, FILE* fp, uint64_t size);
 
     uint32_t calcCheckSum(const std::string& filePath);

--- a/src/lib/PatchDecoder.cc
+++ b/src/lib/PatchDecoder.cc
@@ -460,15 +460,9 @@ bool PatchDecoder::generateFile(
 
         // generate tempfile from diff file's block.
         std::string tmpFileName = path + ".tmp";
-        if (!fileAccess->createTempFile(
-            tmpFileName, fp, file.diffBlockSizeList[i])) {
-            ret = false;
-            break;
-        }
-
-        FILE* tmpFp = fileAccess->openReadFile(tmpFileName);
+        FILE* tmpFp = fileAccess->createTempFile(
+            tmpFileName, fp, file.diffBlockSizeList[i]);
         if (tmpFp == nullptr) {
-            fileAccess->removeFile(tmpFileName);
             ret = false;
             break;
         }

--- a/src/lib/PatchDecoder.cc
+++ b/src/lib/PatchDecoder.cc
@@ -216,9 +216,9 @@ bool PatchDecoder::readFileInfo(File* file, int version) {
         file->oldBlockSizeList.resize(1);
         file->newBlockSizeList.resize(1);
         file->diffBlockSizeList.resize(1);
-        file->oldBlockSizeList[0] = file->fileSize;
+        file->oldBlockSizeList[0] = 0;
         file->newBlockSizeList[0] = file->fileNewSize;
-        file->diffBlockSizeList[0] = file->fileNewSize;
+        file->diffBlockSizeList[0] = file->fileSize;
     }
 
     if (isVerbose) {
@@ -502,8 +502,11 @@ bool PatchDecoder::updateFile(
     const std::string& path, const File& file) {
     // allocate file buffer.
     uint8_t* bufNew = new uint8_t[file.newBlockSizeList[0] + 1];
-    uint8_t* bufOld = new uint8_t[file.oldBlockSizeList[0] + 1];
-    memset(bufNew, 0, file.newBlockSizeList[0] + 1);
+    uint64_t oldFileSize = fileAccess->getFileSize(path);
+    uint64_t bufOldSize = file.oldBlockSizeList[0] == 0
+        ? oldFileSize : file.oldBlockSizeList[0];
+    uint8_t* bufOld = new uint8_t[bufOldSize + 1];
+    memset(bufNew, 0, bufOldSize + 1);
 
     // seek to data begin pos.
     fileAccess->seek(fp, file.filePos + offset, SEEK_SET);
@@ -516,23 +519,19 @@ bool PatchDecoder::updateFile(
         uint64_t oldFileSize;
 
         // read old file's block.
+        uint64_t oldBlockSize = file.oldBlockSizeList[0] == 0
+            ? oldFileSize : file.oldBlockSizeList[i];
         if (!fileAccess->readBlock(
-            oldFp, bufOld, &oldFileSize, file.oldBlockSizeList[i])) {
+            oldFp, bufOld, &oldFileSize, oldBlockSize)) {
             ret = false;
             break;
         }
 
         // generate tempfile from diff file's block.
         std::string tmpFileName = path + ".tmp";
-        if (!fileAccess->createTempFile(
-            tmpFileName, fp, file.diffBlockSizeList[i])) {
-            ret = false;
-            break;
-        }
-
-        FILE* tmpFp = fileAccess->openReadFile(tmpFileName);
+        FILE* tmpFp = fileAccess->createTempFile(
+            tmpFileName, fp, file.diffBlockSizeList[i]);
         if (tmpFp == nullptr) {
-            fileAccess->removeFile(tmpFileName);
             ret = false;
             break;
         }


### PR DESCRIPTION
Ubuntu:bionic + MinGW7.3.0でコンパイルしたものでpatchapplyを実行すると、バイナリデータが破損する。
原因はstd::filesystem::copy_file()を実行したとき、LFがCRLFに勝手に変わってしまったため。
仕方なく自前でread/writeを実装して解消